### PR TITLE
v0.0.2+1.19.4

### DIFF
--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -29,7 +29,7 @@
 				"versions": ">=0.2-SNAPSHOT"
 			},
 			{
-				"id": "owo",
+				"id": "owo-lib",
 				"versions": ">=0.10.3"
 			},
 			{


### PR DESCRIPTION
- update to 1.19.3
- use the item group API instead of mixins