### PR TITLE
v0.0.2+1.19.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: publish
         uses: Kir-Antipov/mc-publish@v3.3
         with:
-          modrinth-id: PxIvFRZv
+          modrinth-id: GaeDYYvY
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
           modrinth-featured: false
 


### PR DESCRIPTION
- update to 1.19.4
- use the item group API instead of mixins